### PR TITLE
Use Status.is_redirection instead of matching on the polymorphic variant

### DIFF
--- a/src/http_lwt_client.ml
+++ b/src/http_lwt_client.ml
@@ -320,14 +320,14 @@ let one_request
       else
         single_request happy_eyeballs ?config tls_config ~meth ~headers ?body uri
         >>= fun (resp, body) ->
-        match resp.status with
-        | #Status.redirection ->
+        if Status.is_redirection resp.status then
           (match Headers.get resp.headers "location" with
            | Some location ->
              Lwt_result.lift (resolve_location ~uri ~location) >>= fun uri ->
              Logs.debug (fun m -> m "following redirect to %s" uri);
              follow_redirect (pred count) uri
            | None -> Lwt_result.return (resp, body))
-        | _ -> Lwt_result.return (resp, body)
+        else
+          Lwt_result.return (resp, body)
     in
     follow_redirect max_redirect uri


### PR DESCRIPTION
The reason behind this is that the new HTTP code 308 (permanent redirect)
is not recognized by HTTP/AF, but already used (e.g. by alt-ergo.ocamlpro.com).