### PR TITLE
request: pass response in body_f, so that an unsuccessful response can be discarded or logged

### DIFF
--- a/app/hurl.ml
+++ b/app/hurl.ml
@@ -21,7 +21,7 @@ let jump () protocol uri meth headers input output no_follow =
         let fd = Unix.openfile fn [ Unix.O_WRONLY ] 0o644 in
         fd, fun () -> Unix.close fd
     in
-    let reply () data =
+    let reply _response () data =
       let bytes = Bytes.of_string data in
       let blen = String.length data in
       let written = Unix.write fd bytes 0 blen in

--- a/src/http_lwt_client.mli
+++ b/src/http_lwt_client.mli
@@ -68,6 +68,6 @@ val request
   -> ?follow_redirect:bool
   -> ?happy_eyeballs:Happy_eyeballs_lwt.t
   -> string
-  -> ('a -> string -> 'a Lwt.t)
+  -> (response -> 'a -> string -> 'a Lwt.t)
   -> 'a
   -> (response * 'a, [> `Msg of string ]) Lwt_result.t


### PR DESCRIPTION
this is in line with the http-mirage-client change //cc @reynir @dinosaure 