### PR TITLE
Fixes: fetch a page which has a redirect with a non-empty body

### DIFF
--- a/app/hurl.ml
+++ b/app/hurl.ml
@@ -18,7 +18,9 @@ let jump () protocol uri meth headers input output no_follow =
     let fd, close = match output with
       | None -> Unix.stdout, fun () -> ()
       | Some fn ->
-        let fd = Unix.openfile fn [ Unix.O_WRONLY ] 0o644 in
+        if Sys.file_exists fn then
+          invalid_arg ("output file " ^ fn ^ " already exists");
+        let fd = Unix.openfile fn [ Unix.O_WRONLY; Unix.O_CREAT ] 0o644 in
         fd, fun () -> Unix.close fd
     in
     let reply _response () data =
@@ -58,7 +60,7 @@ let uri =
 
 let output =
   let doc = "Save body output to a file" in
-  Arg.(value & opt (some file) None & info [ "output" ] ~doc ~docv:"OUTPUT")
+  Arg.(value & opt (some string) None & info [ "output" ] ~doc ~docv:"OUTPUT")
 
 let input =
   let doc = "Upload a file as body" in

--- a/src/http_lwt_client.ml
+++ b/src/http_lwt_client.ml
@@ -373,6 +373,12 @@ let request
       if count = 0 then
         Lwt.return (Error (`Msg "redirect limit exceeded"))
       else
+        let f response acc data =
+          if Status.is_redirection response.status then
+            Lwt.return acc
+          else
+            f response acc data
+        in
         single_request happy_eyeballs ?config tls_config ~meth ~headers ?body uri f f_init
         >>= fun (resp, body) ->
         if Status.is_redirection resp.status then

--- a/src/http_lwt_client.mli
+++ b/src/http_lwt_client.mli
@@ -38,6 +38,8 @@ val pp_response : Format.formatter -> response -> unit
     and returns the response. Each time part of the body is received,
     [f acc part] is called, with [acc] being the last return value of [f]
     (or [init] if it is the first time) and [part] being the body part received.
+    If [follow_redirect] is true (the default), and there's a redirection, [f]
+    is not called with the (potential) body of the redirection page.
 
     By default, up to 5 redirects ([max_redirect]) are followed.
     If [follow_redirect] is false, no redirect is followed (defaults to true).


### PR DESCRIPTION
otherwise, the output is garbled (includes the redirection body).